### PR TITLE
Bumped cloud_firestore version to 0.12.5+2

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.13+1"
+    version: "0.12.5+2"
   collection:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "0.4.0+6"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -382,4 +382,4 @@ packages:
     version: "2.1.15"
 sdks:
   dart: ">=2.2.0 <3.0.0"
-  flutter: ">=1.2.0 <2.0.0"
+  flutter: ">=1.5.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^0.11.0+2
+  cloud_firestore: ^0.12.5+2
   mockito: ^4.0.0
   test: ^1.5.3
 


### PR DESCRIPTION
Required so mock_cloud_firestore does not conflict with other dependencies in current projects.

Please squash before merge.