### PR TITLE
Support for exists, documentID and reference

### DIFF
--- a/lib/factories.dart
+++ b/lib/factories.dart
@@ -8,7 +8,10 @@ MockQuerySnapshot createMockQuerySnapshot(Map<String, dynamic> colData,
   List<MockDocumentChange> docChangeList = [];
   List<MockDocumentSnapshot> docSnapList = [];
   colData.forEach((String key, dynamic value) {
-    MockDocumentSnapshot ds = createDocumentSnapshot(value);
+    MockDocumentReference dr = MockDocumentReference();
+    when(dr.documentID).thenReturn(key);
+    MockDocumentSnapshot ds = createDocumentSnapshot(dr, value);
+    when(ds.reference).thenReturn(dr);
     docSnapList.add(ds);
   });
   added.forEach((value) {
@@ -28,7 +31,7 @@ MockQuerySnapshot createMockQuerySnapshot(Map<String, dynamic> colData,
 
 MockDocumentReference createDocumentReferance(Map<String, dynamic> value) {
   MockDocumentReference r = MockDocumentReference();
-  MockDocumentSnapshot s = createDocumentSnapshot(value);
+  MockDocumentSnapshot s = createDocumentSnapshot(r, value);
   when(r.get()).thenAnswer((_) => Future.value(s));
   return r;
 }
@@ -36,7 +39,7 @@ MockDocumentReference createDocumentReferance(Map<String, dynamic> value) {
 MockDocumentChange createDocumentChange(
     Map<String, dynamic> value, DocumentChangeType type) {
   MockDocumentChange dc = MockDocumentChange();
-  MockDocumentSnapshot ds = createDocumentSnapshot(value);
+  MockDocumentSnapshot ds = createDocumentSnapshot(null, value);
   when(dc.oldIndex).thenReturn(-1);
   when(dc.newIndex).thenReturn(-1);
   when(dc.type).thenReturn(type);
@@ -44,8 +47,11 @@ MockDocumentChange createDocumentChange(
   return dc;
 }
 
-MockDocumentSnapshot createDocumentSnapshot(Map<String, dynamic> value) {
+MockDocumentSnapshot createDocumentSnapshot(MockDocumentReference r, Map<String, dynamic> value) {
   MockDocumentSnapshot ds = MockDocumentSnapshot();
+  if (value != null && value.containsKey("id"))
+    when(ds.documentID).thenReturn(value["id"]);
+  when(ds.reference).thenReturn(r);
   when(ds.data).thenReturn(value);
   when(ds.exists).thenReturn(value != null);
   return ds;

--- a/lib/factories.dart
+++ b/lib/factories.dart
@@ -28,8 +28,7 @@ MockQuerySnapshot createMockQuerySnapshot(Map<String, dynamic> colData,
 
 MockDocumentReference createDocumentReferance(Map<String, dynamic> value) {
   MockDocumentReference r = MockDocumentReference();
-  MockDocumentSnapshot s = MockDocumentSnapshot();
-  when(s.data).thenReturn(value);
+  MockDocumentSnapshot s = createDocumentSnapshot(value);
   when(r.get()).thenAnswer((_) => Future.value(s));
   return r;
 }
@@ -48,5 +47,6 @@ MockDocumentChange createDocumentChange(
 MockDocumentSnapshot createDocumentSnapshot(Map<String, dynamic> value) {
   MockDocumentSnapshot ds = MockDocumentSnapshot();
   when(ds.data).thenReturn(value);
+  when(ds.exists).thenReturn(value != null);
   return ds;
 }

--- a/lib/mock_cloud_firestore.dart
+++ b/lib/mock_cloud_firestore.dart
@@ -44,6 +44,7 @@ class MockCloudFirestore {
     }
     colData.forEach((String key, dynamic value) {
       MockDocumentReference mdr = createDocumentReferance(value);
+      when(mdr.documentID).thenReturn(key);
       when(mcr.document(key)).thenAnswer((_) => mdr);
     });
 

--- a/lib/mock_cloud_firestore.dart
+++ b/lib/mock_cloud_firestore.dart
@@ -17,7 +17,8 @@ class MockCloudFirestore {
     sourceParsed = json.decode(source);
   }
 
-  MockCollectionReference collection(String collectionName, {Map<String, dynamic> source}) {
+  MockCollectionReference collection(String collectionName,
+      {Map<String, dynamic> source}) {
     if (collectionReferenceCache[collectionName] != null) {
       return collectionReferenceCache[collectionName];
     }
@@ -49,11 +50,13 @@ class MockCloudFirestore {
       when(mdr.documentID).thenReturn(key);
       when(mcr.document(key)).thenAnswer((_) => mdr);
 
-      (value as Map<String, dynamic>).forEach((String k, dynamic v){
-        if (v is Map<String, dynamic>) {
+      (value as Map<String, dynamic>).forEach((String k, dynamic v) {
+        if (v is Map<String, dynamic> &&
+            v.length > 0 &&
+            v.entries.first.value is Map<String, dynamic>) {
           Map<String, dynamic> map = Map<String, dynamic>();
           map.addEntries([MapEntry<String, dynamic>(k, v)]);
-          MockCollectionReference c = collection(k,source: map);
+          MockCollectionReference c = collection(k, source: map);
           when(mdr.collection(k)).thenAnswer((_) => c);
         }
       });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.35.4"
+    version: "0.36.4"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   async:
     dependency: transitive
     description:
@@ -64,6 +64,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.6"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.16.0"
   firebase_core:
     dependency: transitive
     description:
@@ -87,7 +94,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.14"
+    version: "0.1.19"
   glob:
     dependency: transitive
     description:
@@ -95,6 +102,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.7"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.14.0+2"
   http:
     dependency: transitive
     description:
@@ -108,7 +122,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.0"
   http_parser:
     dependency: transitive
     description:
@@ -136,14 +150,14 @@ packages:
       name: json_rpc_2
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.1.0"
   kernel:
     dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.14"
+    version: "0.3.19"
   matcher:
     dependency: transitive
     description:
@@ -164,14 +178,14 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6+2"
+    version: "0.9.6+3"
   mockito:
     dependency: "direct main"
     description:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   multi_server_socket:
     dependency: transitive
     description:
@@ -262,7 +276,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2+5"
+    version: "0.2.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -358,7 +372,7 @@ packages:
       name: vm_service_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.6+1"
+    version: "0.2.6+2"
   watcher:
     dependency: transitive
     description:
@@ -372,14 +386,14 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.12"
+    version: "1.0.13"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.15"
+    version: "2.1.16"
 sdks:
-  dart: ">=2.2.0 <3.0.0"
+  dart: ">=2.2.2 <3.0.0"
   flutter: ">=1.5.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mock_cloud_firestore
 description: Easier way to mock cloud_firestore, without using `Firestore.channel.setMockMethodCallHandler`
-version: 0.0.7
+version: 0.0.8
 author: Ozan Turksever <ozan.turksever@gmail.com>
 homepage: https://github.com/ozanturksever/mock_cloud_firestore
 

--- a/test/mock_cloud_firestore_test.dart
+++ b/test/mock_cloud_firestore_test.dart
@@ -19,12 +19,24 @@ void main() {
   "projects": {
     "1": {
       "id": "1",
-      "title": "test project 1"
+      "title": "test project 1",
+      "tasks": {
+        "101": {
+          "id": "101",
+          "taskId": "1",
+          "projectPriority": true
+        },
+        "102": {
+          "id": "102",
+          "taskId": "2",
+          "projectPriority": false
+        }
+      }
     },
     "2": {
       "id": "2",
       "title": "test project 2"
-    }    
+    }
   },
   "tasks": {
     "1": {
@@ -88,6 +100,7 @@ void main() {
     MockDocumentSnapshot docSnapshot = await doc.get();
     expect(docSnapshot, isNotNull);
     expect(docSnapshot.data, isNull);
+    expect(docSnapshot.exists, false);
   });
 
   test('get document snaphots from collection', () async {
@@ -102,7 +115,33 @@ void main() {
 
     MockDocumentSnapshot docSnap = first.documents[0];
     expect(docSnap.data["id"], "1");
+    expect(docSnap.exists, true);
+    expect(docSnap.documentID, "1");
+    expect(docSnap.reference, isNotNull);
   });
+
+  test('get sub-collection from document', () {
+    MockCollectionReference col = mcf.collection("projects");
+    expect(col, isNotNull);
+    MockDocumentReference doc = col.document("1");
+    expect(doc, isNotNull);
+    // MockDocumentSnapshot docSnapshot = await doc.get();
+    // expect(docSnapshot, isNotNull);
+
+    CollectionReference cr = doc.collection("tasks");
+    expect(cr, isNotNull);
+    Stream<QuerySnapshot> qs = cr.snapshots();
+    expect(qs, isNotNull);
+  });
+
+  test('get document from collection', () {
+    MockCollectionReference col = mcf.collection("projects");
+    expect(col, isNotNull);
+    MockDocumentReference r = col.document("1");
+    expect(r, isNotNull);
+    expect(r.documentID, "1");
+  });
+
   test('add new document', () async {
     MockCollectionReference col = mcf.collection("projects");
 


### PR DESCRIPTION
I am running in to the issue that mock_cloud_firestore does not support `.exists` on DocumentSnapshots. Since @tresheffron seems to have this implemented in his fork, I would like to propose to merge this.